### PR TITLE
Update to build image using jlink

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -14,7 +14,7 @@ steps:
   commands:
   - n=0; while [ "$n" -lt 60 ] && [ ! docker stats --no-stream ]; do n=$(( n + 1 )); sleep 1; done
   # The drone docker plugin uses the entries in the .tags file to tag the image
-  - printf "18.%s.0,latest" $(date +%Y%m%d%H%M) > .tags
+  - printf "18-jlink.%s.0,latest" $(date +%Y%m%d%H%M) > .tags
   - docker build -t cop-java-runner:latest .
   when:
     event:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,20 @@
-FROM docker.io/library/eclipse-temurin:18
+FROM docker.io/library/eclipse-temurin:18 as jre-build
+
+RUN ${JAVA_HOME}/bin/jlink \
+        --add-modules ALL-MODULE-PATH \
+        --compress=2 \
+        --no-header-files \
+        --no-man-pages \
+        --strip-debug \
+        --output /javaruntime
+
+
+FROM ubuntu:latest
+
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH "${JAVA_HOME}/bin:${PATH}"
+
+COPY --from=jre-build /javaruntime "${JAVA_HOME}"
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 


### PR DESCRIPTION
Build the image using jlink. 

By building the image with jlink, only the components required to actually run a Java application are incorporated. Other components typically found in a JDK are removed. This results in a much smaller image size and a more secure image.

While Adoptium are now shipping Eclipse-Termurin JREs, they are larger than the image produced using jlink.