### PR TITLE
Split step to get time and date to separate actions job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,9 +4,19 @@ on:
   workflow_dispatch:
 
 jobs:
+  get_datetime:
+    runs-on: ubuntu-latest
+    outputs:
+      datetime: ${{ steps.datetime.outputs.now }}
+
+    steps:
+      - id: datetime
+        run: echo "::set-output name=now::$(date +%Y%m%d%H%M)"
+
   build:
     name: Build container images
     runs-on: ubuntu-latest
+    needs: get_datetime
     strategy:
       matrix:
         java-version: ['11', '16', '17', '18']
@@ -14,10 +24,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-
-      - name: Get date and time
-        id: date
-        run: echo "::set-output name=datetime::$(date +%Y%m%d%H%M)"
 
       - name: Login to Quay.io
         uses: docker/login-action@v2
@@ -37,8 +43,7 @@ jobs:
           tags: cop-java-runner:${{ matrix.java-version }}.test
 
       - name: Basic sanity check of image before push
-        run: |
-          docker run --rm cop-java-runner:${{ matrix.java-version }}.test java --version
+        run: docker run --rm cop-java-runner:${{ matrix.java-version }}.test java --version
 
       - name: Build Java Runner ${{ matrix.java-version }} and Push to Quay
         uses: docker/build-push-action@v3
@@ -47,4 +52,4 @@ jobs:
           context: .
           pull: true
           push: true
-          tags: quay.io/ukhomeofficedigital/cop-java-runner:${{ matrix.java-version }}.${{ steps.date.outputs.datetime }}.0
+          tags: quay.io/ukhomeofficedigital/cop-java-runner:${{ matrix.java-version }}.${{ needs.get_datetime.outputs.datetime }}.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,9 @@
 ---
 name: Build Images
 on:
-  workflow_dispatch:
+  push:
+    branches:
+      - 'time-sep-job'
 
 env:
   IMAGE_NAME: cop-java-runner

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,7 @@
 ---
 name: Build Images
 on:
-  push:
-    branches:
-      - 'time-sep-job'
+  workflow_dispatch:
 
 env:
   IMAGE_NAME: cop-java-runner

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,10 @@ name: Build Images
 on:
   workflow_dispatch:
 
+env:
+  IMAGE_NAME: cop-java-runner
+  IMAGE_REPO: quay.io/ukhomeofficedigital
+
 jobs:
   get_datetime:
     runs-on: ubuntu-latest
@@ -40,10 +44,10 @@ jobs:
           load: true
           pull: true
           push: false
-          tags: cop-java-runner:${{ matrix.java-version }}.test
+          tags: ${{ env.IMAGE_NAME }}:${{ matrix.java-version }}.test
 
       - name: Basic sanity check of image before push
-        run: docker run --rm cop-java-runner:${{ matrix.java-version }}.test java --version
+        run: docker run --rm ${{ env.IMAGE_NAME }}:${{ matrix.java-version }}.test java --version
 
       - name: Build Java Runner ${{ matrix.java-version }} and Push to Quay
         uses: docker/build-push-action@v3
@@ -52,4 +56,4 @@ jobs:
           context: .
           pull: true
           push: true
-          tags: quay.io/ukhomeofficedigital/cop-java-runner:${{ matrix.java-version }}.${{ needs.get_datetime.outputs.datetime }}.0
+          tags: ${{ env.IMAGE_REPO }}/${{ env.IMAGE_NAME }}:${{ matrix.java-version }}.${{ needs.get_datetime.outputs.datetime }}.0


### PR DESCRIPTION
Splits the step to get the date and time to a separate actions job.

This is required to prevent a possible mismatch in the time and date set for the image tags that could occur due to the scheduling of matrix jobs at slightly different times